### PR TITLE
Demo 2 Add delete usage example

### DIFF
--- a/GridStack.Blazor.Demo/GridStack.Blazor.Demo.Client/Components/ValueAppWidget.razor
+++ b/GridStack.Blazor.Demo/GridStack.Blazor.Demo.Client/Components/ValueAppWidget.razor
@@ -1,4 +1,4 @@
 <div class="container">
-    <h1>164</h1>
+    <h1>@(new Random().NextInt64(200))</h1>
     <h2>employees</h2>
 </div>

--- a/GridStack.Blazor.Demo/GridStack.Blazor.Demo.Client/Pages/Demo2.razor
+++ b/GridStack.Blazor.Demo/GridStack.Blazor.Demo.Client/Pages/Demo2.razor
@@ -1,4 +1,5 @@
 @page "/demo2"
+@using GridStack.Blazor.Demo.Client.Components
 
 <PageTitle>Demo 2: Runtime Markup Components</PageTitle>
 
@@ -19,8 +20,12 @@
 
                 @foreach (var widget in _widgets)
                 {
-                    <GsWidget Options="@ToOptions(widget)">
-                        @widget.Id
+                    <GsWidget @key="widget.Id" Options="@ToOptions(widget)">
+                          <AppWidget
+                                Id=@widget.Id
+                                CanDelete="true"
+                                WidgetType="@WidgetType.Value"
+                                OnDelete="@OnDeleteWidget"/>
                     </GsWidget>
                 }
 
@@ -77,13 +82,18 @@
         var widget = new WidgetHolder
         {
             Id = Guid.NewGuid().ToString(),
-            X = 0,
-            Y = 0,
             W = 2,
             H = 1
         };
         
         _widgets.Add(widget);
+    }
+
+    private async Task OnDeleteWidget(string id)
+    {
+        _widgets.RemoveAll(w => w.Id == id);
+
+        await _grid.RemoveWidget(id , removeDom:false);
     }
 
     private async Task OnUpdateWidget()

--- a/GridStack.Blazor/GsGrid.razor.cs
+++ b/GridStack.Blazor/GsGrid.razor.cs
@@ -151,9 +151,9 @@ public sealed partial class GsGrid : IAsyncDisposable
         return await _instance!.InvokeAsync<bool>("float");
     }
 
-    public async Task<int> GetCellHeight()
+    public async Task<double> GetCellHeight()
     {
-        return await _instance!.InvokeAsync<int>("getCellHeight");
+        return await _instance!.InvokeAsync<double>("getCellHeight");
     }
 
     public async Task<GsCoordinate> GetCellFromPixel(uint top, uint left, bool? useOffset = null)


### PR DESCRIPTION
Demo 2 does not have a use case for deleting widgets; this PR provides that example. The @key directive is used to avoid rendering issues when deleting components.